### PR TITLE
bug: no Module kombo.matcher

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,7 +1,7 @@
 django==1.11.4
 djangorestframework==3.4.0
-redis==2.10.6
-kombu==4.2.1
+redis
+kombu
 pillow
 otpauth
 flake8-quotes


### PR DESCRIPTION
2019.5.5 

用最新版的kombu和redis可以解决unhealthy (no Module kombo.matcher) (最新版kombu需要redis >= 3.2.0) 

当前版本 run_test.py PE相关的内容都Fail (锁定版本也会Fail)